### PR TITLE
Add Code Review Lab to learning platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ My personal collection of resources (mostly tools and training materials) for so
 
 - [OWASP's Secure Coding Dojo Example](https://owasp.org/SecureCodingDojo/codereview101)
 - [Secure Code Warrior](https://www.securecodewarrior.com/products/training-ground) (paid service with free trial)
+- [Code Review Lab](https://www.codereviewlab.com/) (freemium model)
 
 ### Vulnerable Apps
 


### PR DESCRIPTION
Added [Code Review Lab](https://www.codereviewlab.com/) to the list of platforms to practice secure code review